### PR TITLE
feat: card 컴포넌트 구현

### DIFF
--- a/components/atoms/RatingCircles.vue
+++ b/components/atoms/RatingCircles.vue
@@ -1,0 +1,40 @@
+<template>
+  <div :class="`card-review-rating ${props.color}`">
+    <template v-for="(n, ratingCircleIndex) of props.count" :key="`rating-circle-${ratingCircleIndex}`">
+      <p class="circle">⏺</p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  count: number;
+  color: string;
+}
+
+definePageMeta({
+  name: 'RatingCircles',
+});
+
+const props = withDefaults(defineProps<Props>(), {
+  count: 0,
+  color: 'gray',
+});
+</script>
+
+<style scoped lang="scss">
+.card-review-rating {
+  display: flex;
+  gap: 2px;
+}
+.circle {
+  @include font_3060;
+  line-height: 1;
+}
+.yellow {
+  color: $systemYellow;
+}
+.gray {
+  color: $systemBorderColor;
+}
+</style>

--- a/components/molecules/CardInfo.vue
+++ b/components/molecules/CardInfo.vue
@@ -1,0 +1,83 @@
+<template>
+  <section :class="['card-info-container', `card-info-container--${cardLayout}`]">
+    <div v-if="isVertical" class="card-info-label">{{ label }}</div>
+    <div class="card-info-title">{{ title }}</div>
+    <div :class="['card-info-description', `card-info-description--${cardLayout}`]">{{ description }}</div>
+    <div v-if="isVertical" class="card-info-status">
+      <div class="card-info-status__highlight">{{ highlight }}</div>
+      <div class="card-info-status__cross-out">{{ crossOut }}</div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { CardLayout, ECardLayout } from '~~/types';
+
+interface Props {
+  cardLayout: CardLayout;
+  label: string;
+  title: string;
+  description: string;
+  highlight: string;
+  crossOut: string;
+}
+definePageMeta({
+  name: 'CardInfo',
+});
+const props = withDefaults(defineProps<Props>(), {
+  cardLayout: ECardLayout.VERTICAL,
+  label: '',
+  title: '',
+  description: '',
+  highlight: '',
+  crossOut: '',
+});
+const isVertical = computed(() => props.cardLayout === ECardLayout.VERTICAL);
+</script>
+
+<style scoped lang="scss">
+.card-info-container {
+  display: flex;
+  flex-direction: column;
+  &--horizon {
+    padding: 20px;
+  }
+  &--vertical {
+    padding: 20px;
+  }
+}
+.card-info-label {
+  color: $systemLightGray;
+  @include font_1440;
+}
+.card-info-title {
+  color: $black;
+  @include font_1660;
+  @include textEllipsis(1);
+}
+.card-info-description {
+  @include font_1640;
+  color: $systemDarkGray;
+  margin: 10px 0;
+  &--horizon {
+    @include textEllipsis(3);
+  }
+  &--vertical {
+    @include textEllipsis(2);
+  }
+}
+.card-info-status {
+  display: flex;
+  align-items: baseline;
+  gap: 15px;
+}
+.card-info-status__highlight {
+  color: $systemRed;
+  @include font_1440;
+}
+.card-info-status__cross-out {
+  @include font_1240;
+  color: $systemLightGray;
+  text-decoration: line-through;
+}
+</style>

--- a/components/molecules/CardReview.vue
+++ b/components/molecules/CardReview.vue
@@ -1,0 +1,88 @@
+<template>
+  <section v-if="canShowReview" :class="['card-review-container', `card-review-container--${cardLayout}`]">
+    <div class="card-review-rating">
+      <RatingCircles :count="rating" color="yellow" />
+      <RatingCircles :count="5 - rating" color="gray" />
+      <div v-if="canShowAuthor" class="card-review-rating__author"><span>|</span>{{ author }}</div>
+    </div>
+    <div v-if="canShowText" class="card-review-content">
+      <p class="card-review-content__text">{{ reviewText }}</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { CardLayout, CardRating, CardTheme, ECardLayout, ECardTheme } from '~~/types';
+import { AtomsRatingCircles as RatingCircles } from '#components';
+interface Props {
+  cardLayout: CardLayout;
+  rating: CardRating;
+  reviewText: string;
+  author: string;
+  theme: CardTheme;
+}
+
+definePageMeta({
+  name: 'CardReview',
+  components: {
+    RatingCircles,
+  },
+});
+
+const props = withDefaults(defineProps<Props>(), {
+  cardLayout: ECardLayout.VERTICAL,
+  rating: 0,
+  reviewText: '',
+  author: '',
+  theme: ECardTheme.DEFAULT,
+});
+
+const hasAuthor = computed(() => props.author.length > 0);
+const canShowReview = computed(() => props.theme !== ECardTheme.REMOVE);
+const canShowAuthor = computed(() => props.cardLayout === ECardLayout.HORIZON && hasAuthor.value);
+const canShowText = computed(() => props.theme === ECardTheme.DEFAULT && props.cardLayout === ECardLayout.VERTICAL);
+</script>
+
+<style scoped lang="scss">
+.card-review-container {
+  &--horizon {
+    padding: 0 20px 0;
+  }
+  &--vertical {
+    position: relative;
+    padding: 10px 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    height: 75px;
+  }
+}
+.card-review-container--vertical::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: '';
+  border: 1px solid $systemBorderColor;
+  border-top: 0px;
+  width: 100%;
+}
+.card-review-rating {
+  display: flex;
+  @include font_2040;
+  gap: 2px;
+  align-items: center;
+}
+.card-review-rating__author {
+  color: $systemLightGray;
+  & > span {
+    padding: 0 10px;
+  }
+}
+.card-review-content {
+  @include font_1440;
+}
+.card-review-content__text {
+  @include textEllipsis(1);
+}
+</style>

--- a/components/molecules/CardThumbnail.vue
+++ b/components/molecules/CardThumbnail.vue
@@ -1,0 +1,55 @@
+<template>
+  <img
+    ref="imageRef"
+    :class="['card-thumbnail-image', `card-thumbnail-image--${cardLayout}`]"
+    :src="defaultSrc"
+    :data-src="imgSrc"
+  />
+</template>
+
+<script setup lang="ts">
+import { CardLayout, ECardLayout } from '~~/types';
+
+interface Props {
+  cardLayout: CardLayout;
+  imgSrc: string;
+  defaultSrc: string;
+}
+
+definePageMeta({
+  name: 'CardThumbnail',
+});
+
+withDefaults(defineProps<Props>(), {
+  cardLayout: ECardLayout.VERTICAL,
+  imgSrc: '',
+  defaultSrc: '',
+});
+
+const imageRef = ref<HTMLDivElement | null>(null);
+const setImageUrl = () => {
+  const imgTag = imageRef.value! as HTMLImageElement;
+  imgTag.src = imgTag.dataset.src!;
+};
+
+const DELAY_TIME_MS = 250;
+
+onMounted(() => {
+  setTimeout(() => {
+    setImageUrl();
+  }, DELAY_TIME_MS);
+});
+</script>
+
+<style scoped lang="scss">
+.card-thumbnail-image {
+  width: 100%;
+  &--horizon {
+    border-radius: 5px 0px 0px 5px;
+    height: 100%;
+  }
+  &--vertical {
+    border-radius: 5px 5px 0px 0px;
+  }
+}
+</style>

--- a/components/organisms/TheCard.vue
+++ b/components/organisms/TheCard.vue
@@ -1,0 +1,100 @@
+<template>
+  <div :class="['card', `card--${cardLayout}`]">
+    <div class="card-thumbnail">
+      <CardThumbnail
+        :class="`card-thumbnail--${cardLayout}`"
+        :card-layout="cardLayout"
+        :img-src="IMAGE_SRC"
+        :default-src="DEFAULT_SRC"
+      />
+    </div>
+    <div :class="['card-content', `card-content--${cardLayout}`]">
+      <CardInfo
+        :card-layout="cardLayout"
+        :label="cardData.label"
+        :title="cardData.title"
+        :description="cardData.description"
+        :highlight="cardData.highlight"
+        :cross-out="cardData.crossOut"
+      />
+      <CardReview
+        :theme="theme"
+        :card-layout="cardLayout"
+        :rating="cardData.rating"
+        :review-text="cardData.reviewText"
+        :author="cardData.author"
+      />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { IMAGE_SRC, DEFAULT_SRC } from '~~/static/variable';
+import { useCardStore } from '~~/stores';
+import {
+  MoleculesCardThumbnail as CardThumbnail,
+  MoleculesCardInfo as CardInfo,
+  MoleculesCardReview as CardReview,
+} from '#components';
+import { CardLayout, CardTheme, ECardLayout, ECardTheme } from '~~/types';
+interface Props {
+  cardLayout: CardLayout;
+  theme: CardTheme;
+}
+definePageMeta({
+  name: 'TheCard',
+  components: {
+    CardThumbnail,
+    CardInfo,
+    CardReview,
+  },
+});
+
+withDefaults(defineProps<Props>(), {
+  cardLayout: ECardLayout.VERTICAL,
+  rating: 0,
+  theme: ECardTheme.DEFAULT,
+});
+const cardStore = useCardStore();
+const { cardData } = storeToRefs(cardStore);
+</script>
+
+<style scoped lang="scss">
+.card {
+  display: flex;
+  border-radius: 5px;
+  border: 1px solid $systemBorderColor;
+  &--horizon {
+    justify-content: flex-start;
+    flex-direction: row;
+    min-width: 520px;
+    max-width: 880px;
+  }
+  &--vertical {
+    flex-direction: column;
+    justify-content: flex-start;
+    height: 100%;
+    max-width: 390px;
+    min-width: 250px;
+  }
+}
+.card-thumbnail {
+  flex-basis: 40%;
+  &--horizon {
+    height: 100%;
+  }
+}
+.card-content {
+  flex-basis: 60%;
+  &--horizon {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+  }
+  &--vertical {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+  }
+}
+</style>

--- a/pages/card/index.vue
+++ b/pages/card/index.vue
@@ -1,0 +1,37 @@
+<template>
+  <div v-if="rendering" class="card-page">
+    <TheCard card-layout="vertical" theme="default" />
+    <TheCard card-layout="vertical" theme="simple" />
+    <TheCard card-layout="vertical" theme="remove" />
+    <TheCard card-layout="horizon" theme="default" />
+  </div>
+</template>
+<script setup lang="ts">
+import { OrganismsTheCard as TheCard } from '#components';
+import { useCardStore } from '~~/stores';
+definePageMeta({
+  layout: 'default',
+  components: {
+    TheCard,
+  },
+});
+const cardStore = useCardStore();
+const { setCardData } = cardStore;
+const rendering = ref<boolean>(false);
+onMounted(() => {
+  setCardData();
+  rendering.value = true;
+});
+</script>
+
+<style scoped lang="scss">
+.card-page {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 50px;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 100px;
+}
+</style>

--- a/static/variable.ts
+++ b/static/variable.ts
@@ -1,0 +1,4 @@
+const IMAGE_SRC = 'https://loremflickr.com/500/500?lock=1';
+const DEFAULT_SRC = '/images/default.jpg';
+
+export { IMAGE_SRC, DEFAULT_SRC };


### PR DESCRIPTION
- props
  - cardLayout를 통한 vertical, horizon 타입의 카드 구분
  - theme를 통해 카드의 review 부분 정보 구성
- 컴포넌트 구조
  - TheCard 컴포넌트는 Organisms
  - 그 하위에 CardInfo, CardReview, CardThumbnail molecues로 구성
  - atoms 단위의 RatingCircles 도 구현
- 상수는 variable 파일에 등록하여 사용 (이미지 url)