### PR TITLE
feat: input 컴포넌트 구현

### DIFF
--- a/components/organisms/TheInput.vue
+++ b/components/organisms/TheInput.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="textarea">
+    <div
+      :class="[
+        'textarea-wrapper',
+        focus && 'textarea-wrapper--focus',
+        disabled && 'textarea-wrapper--disabled',
+        readonly && 'textarea-wrapper--readonly',
+      ]"
+    >
+      <textarea
+        v-model="text"
+        class="textarea-input"
+        :placeholder="placeholder"
+        name="textarea"
+        :maxlength="maxLength"
+        :disabled="disabled"
+        :readonly="readonly"
+        @focus="onFocus"
+        @blur="onBlur"
+        @change="onChange"
+      ></textarea>
+      <p class="textarea-count">{{ textCount }}</p>
+    </div>
+    <button
+      v-if="!readonly && !disabled"
+      id="save"
+      :class="['textarea-save', focus && 'textarea-save--focus', !isChanged && 'textarea-save--disabled']"
+      :disabled="!isChanged"
+      type="button"
+      @click="onClickSave"
+    >
+      Save
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  placeholder: string;
+  disabled: boolean;
+  readonly: boolean;
+  maxLength: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  placeholder: '',
+  disabled: false,
+  readonly: false,
+  maxLength: 500,
+});
+const focus = ref<boolean>(false);
+const text = ref<string>('');
+const savedText = ref<string>('');
+const onFocus = () => {
+  if (props.readonly) {
+    return;
+  }
+  focus.value = true;
+};
+const onClickSave = () => {
+  savedText.value = text.value;
+  focus.value = false;
+};
+const onBlur = (e: FocusEvent) => {
+  const relatedTarget = e.relatedTarget as HTMLElement | null;
+  if (relatedTarget && relatedTarget.id === 'save') {
+    return;
+  }
+  text.value = savedText.value;
+  focus.value = false;
+};
+
+const isChanged = computed(() => savedText.value !== text.value);
+const textCount = computed(() => text.value.length);
+</script>
+
+<style scoped lang="scss">
+textarea:disabled {
+  background: none;
+  color: $systemOrange;
+  cursor: not-allowed;
+}
+textarea:read-only {
+  background: #fafafa;
+}
+.textarea {
+  display: flex;
+  gap: 5px;
+  height: 100px;
+}
+.textarea-wrapper {
+  position: relative;
+  width: 100%;
+  border: 1px solid $systemBorderColor;
+  display: flex;
+  &--focus {
+    outline: 1px solid $systemFocusColor;
+  }
+  &--disabled {
+    background: #fafafa;
+    opacity: 0.5;
+  }
+  &--readonly {
+    background: #fafafa;
+  }
+}
+
+.textarea-input {
+  width: 100%;
+  margin: 10px 10px 20px;
+  border: none;
+  @include font_1440;
+  border-radius: 2px;
+}
+.textarea-input:focus {
+  border: none;
+  outline: none;
+}
+
+.textarea-count {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  margin: 0 10px 0 0;
+  color: $black;
+  @include font_1440;
+}
+
+.textarea-save {
+  border: 1px solid $systemBorderColor;
+  color: $systemLightGray;
+  flex-basis: 10%;
+  @include font_1440;
+  border-radius: 2px;
+}
+.textarea-save--focus {
+  color: $systemFocusColor;
+}
+.textarea-save--disabled {
+  color: $black;
+  opacity: 0.3;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,18 +1,13 @@
 <template>
-  <div>
-    <div>Index 페이지입니다.</div>
-    <TheCard />
-    <TheInput />
-  </div>
+  <div class="main"></div>
 </template>
 <script setup lang="ts">
-import { TheCard, TheInput } from '#components';
 definePageMeta({
   layout: 'default',
-  components: {
-    TheCard,
-    TheInput,
-  },
+});
+const router = useRouter();
+onMounted(() => {
+  router.push('/card');
 });
 </script>
 

--- a/pages/input/index.vue
+++ b/pages/input/index.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="input-page">
+    <div class="input-page-case">
+      <p class="input-page-title">default</p>
+      <TheInput placeholder="default 예시입니다." :disabled="false" :readonly="false" max-length="500" />
+    </div>
+    <div class="input-page-case">
+      <p class="input-page-title">disabled</p>
+      <TheInput placeholder="disabled 예시입니다." :disabled="true" :readonly="false" max-length="500" />
+    </div>
+    <div class="input-page-case">
+      <p class="input-page-title">readonly</p>
+      <TheInput placeholder="readonly 예시입니다." :disabled="false" :readonly="true" max-length="500" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { OrganismsTheInput as TheInput } from '#components';
+definePageMeta({
+  layout: 'default',
+  components: {
+    TheInput,
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.input-page {
+  padding: 0px 40px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.input-page-case {
+  width: 100%;
+}
+.input-page-title {
+  @include font_2070;
+}
+</style>


### PR DESCRIPTION
- focus 시 focus css 적용 및 입력가능
- blur시 클릭한 요소가 save 버튼이라면 텍스트 저장, 그 외 요소라면 저장하지 않고 입력했던 텍스트 무시
- readonly, disabled, maxlength, placeholder 상태를 props로 전달받아 컴포넌트 구현